### PR TITLE
Confiture does not load safely YAML file

### DIFF
--- a/confiture/__init__.py
+++ b/confiture/__init__.py
@@ -29,7 +29,7 @@ class Confiture(object):
     def __parse(self):
         try:
             with open(self._tpl_file, 'r') as ymlfile:
-                self.__tpl = yaml.load(ymlfile)
+                self.__tpl = yaml.safe_load(ymlfile)
             # In case the parsed file was empty
             if self.__tpl is None:
                 self.__tpl = dict()
@@ -49,7 +49,7 @@ class Confiture(object):
             raise ConfigFileError("You must load a template file first -- aborting")
         try:
             with open(config_path, 'r') as ymlfile:
-                self.config = yaml.load(ymlfile)
+                self.config = yaml.safe_load(ymlfile)
         except (IOError, yaml.error.YAMLError):
             raise ConfigFileError("File \"{0}\" not found -- aborting".format(config_path))
         self.__check_required_fields(self.__tpl, self.config)

--- a/tests/yaml/security/unsafe_loading.yaml
+++ b/tests/yaml/security/unsafe_loading.yaml
@@ -1,0 +1,1 @@
+unsafe: !!python/object/apply:copyright []

--- a/tests/yaml/test_security.py
+++ b/tests/yaml/test_security.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from confiture import Confiture, ConfigFileError
+
+def test_unsafe_loading_config():
+    confiture = Confiture('tests/yaml/template/empty.yaml')
+    with pytest.raises(ConfigFileError):
+        confiture.check('tests/yaml/security/unsafe_loading.yaml')


### PR DESCRIPTION
I expect from a library like Confiture used in big infosec projects to be secure by default. This is not currently the case.

As indicated in the [PyYAML documentation](http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML):

> PyYAML allows you to construct a Python object of any type.
> [...]
> Note that the ability to construct an arbitrary Python object may be dangerous if you receive a YAML document from an untrusted source such as the Internet. The function yaml.safe_load limits this ability to simple Python objects like integers or lists. 

I have only added a test for the config files but template files are also concerned. It is just hard to test it with the way exceptions are raised in Confiture and I did not want to refactor that in the same pull request.

Full code execution example with Confiture is left as an exercise for the reader.
