### PR TITLE
Unit tests pass on Travis CI for all expected versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
   - "pypy3"
 script: python setup.py test


### PR DESCRIPTION
This contribution drop the execution of the unit tests on
Python 3.2. Python 3.2 is not supported by pytest anymore [1]
and there are no more security updates [2]. confiture should
not encourage the use of an abandoned version of Python.

Also, this contribution adds the current Python 3 version (3.6)
to the list of the tested environments.

[1] https://github.com/pytest-dev/pytest/pull/1678
[2] https://www.python.org/dev/peps/pep-0392/#lifespan